### PR TITLE
refactor: clean up helper files and change build folder from dist to lib 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-dist/
+lib/
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
     "name": "sfuapi",
     "version": "1.0.0",
     "description": "An asynchronous TypeScript wrapper for the SFU API.",
-    "main": "dist/index.js",
-    "types": "dist/types/index.d.ts",
+    "main": "lib/index.js",
+    "types": "lib/types/index.d.ts",
+    "files": [
+        "lib"
+    ],
     "scripts": {
         "prepare": "ts-patch install -s",
         "test": "jest",
         "build": "tsc",
-        "clean": "rimraf dist",
+        "clean": "rimraf lib",
         "format:check": "prettier --list-different './**/*.ts' './**/*.json'",
         "format:fix": "prettier --write './**/*.ts' './**/*.json'"
     },

--- a/src/api-types/requests.ts
+++ b/src/api-types/requests.ts
@@ -2,5 +2,9 @@ type CourseOutlinesCurrent = 'current';
 
 export type CourseOutlinesYear = number | CourseOutlinesCurrent;
 
-type Term = 'fall' | 'spring' | 'summer';
+enum Term {
+    Fall = 'fall',
+    Spring = 'spring',
+    Summer = 'summer',
+}
 export type CourseOutlinesTerm = Term | CourseOutlinesCurrent;

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -1,69 +1,71 @@
 import urls from '@utils/urls.json';
-import type {
-    CourseOutlinesYear,
-    CourseOutlinesTerm,
-} from '@api-types';
+import type { CourseOutlinesYear, CourseOutlinesTerm } from '@api-types';
 import axios, { AxiosResponse } from 'axios';
 
-function generateURLForSFUAPI(baseUrl: string, ...parameters: (number | string)[]) {
+function generateURLForSFUApi(
+    baseUrl: string,
+    ...parameters: (number | string)[]
+) {
     return `${baseUrl}?${parameters.join('/')}`;
 }
 
-async function requestSFUAPI(
-    baseUrl: string,
+type requestSFUApiFunction = (
     ...parameters: (number | string)[]
-): Promise<AxiosResponse> {
-    try {
-        return await axios.get(
-            generateURLForSFUAPI(baseUrl, ...parameters),
-        );
-    } catch (error) {
-        throw error;
-    }
+) => Promise<AxiosResponse>;
+
+function generateRequestSFUApiFunction(baseUrl: string): requestSFUApiFunction {
+    return async (
+        ...parameters: (number | string)[]
+    ): Promise<AxiosResponse> => {
+        try {
+            return await axios.get(
+                generateURLForSFUApi(baseUrl, ...parameters),
+            );
+        } catch (error) {
+            throw error;
+        }
+    };
 }
 
-export async function requestSFUCourseOutlinesAPI(
-    ...parameters: (number | string)[]
-): Promise<AxiosResponse> {
-    return await requestSFUAPI(urls.courseOutlines.baseUrl, ...parameters);
-}
+export const requestSFUCourseOutlinesApi = generateRequestSFUApiFunction(
+    urls.courseOutlines.baseUrl,
+);
+export const requestSFUAcademicCalendarApi = generateRequestSFUApiFunction(
+    urls.academicCalendar.baseUrl,
+);
 
-export async function requestSFUAcademicCalendarAPI(
+type requestSFUAcademicCalendarApiSectionFunction = (
+    year: CourseOutlinesYear,
+    term: CourseOutlinesTerm,
     ...parameters: (number | string)[]
-): Promise<AxiosResponse> {
-    return await requestSFUAPI(urls.academicCalendar.baseUrl, ...parameters);
-}
+) => Promise<AxiosResponse>;
 
-async function requestSFUAcademicCalendarAPISection(
-    year: CourseOutlinesYear = 'current',
-    term: CourseOutlinesTerm = 'current',
+function generateRequestSFUAcademicCalendarApiSectionFunction(
     section: string,
-    ...parameters: (number | string)[]
-): Promise<AxiosResponse> {
-    return await requestSFUAcademicCalendarAPI(year, term, section, ...parameters);
+): requestSFUAcademicCalendarApiSectionFunction {
+    return async (
+        year: CourseOutlinesYear = 'current',
+        term: CourseOutlinesTerm = 'current',
+        ...parameters: (number | string)[]
+    ): Promise<AxiosResponse> => {
+        return await requestSFUAcademicCalendarApi(
+            year,
+            term,
+            section,
+            ...parameters,
+        );
+    };
 }
 
-export async function requestSFUAcademicCalendarAPIAreasOfStudy(
-    year: CourseOutlinesYear = 'current',
-    term: CourseOutlinesTerm = 'current',
-    ...parameters: (number | string)[]
-): Promise<AxiosResponse> {
-    return await requestSFUAcademicCalendarAPISection(year, term, urls.academicCalendar.areasOfStudy, ...parameters);
-}
-
-export async function requestSFUAcademicCalendarAPICourses(
-    year: CourseOutlinesYear = 'current',
-    term: CourseOutlinesTerm = 'current',
-    ...parameters: (number | string)[]
-): Promise<AxiosResponse> {
-    return await requestSFUAcademicCalendarAPISection(year, term, urls.academicCalendar.courses, ...parameters);
-}
-
-export async function requestSFUAcademicCalendarAPIPrograms(
-    year: CourseOutlinesYear = 'current',
-    term: CourseOutlinesTerm = 'current',
-    ...parameters: (number | string)[]
-): Promise<AxiosResponse> {
-    return await requestSFUAcademicCalendarAPISection(year, term, urls.academicCalendar.programs, ...parameters);
-}
-
+export const requestSFUAcademicCalendarAPIAreasOfStudy =
+    generateRequestSFUAcademicCalendarApiSectionFunction(
+        urls.academicCalendar.areasOfStudy,
+    );
+export const requestSFUAcademicCalendarAPICourses =
+    generateRequestSFUAcademicCalendarApiSectionFunction(
+        urls.academicCalendar.courses,
+    );
+export const requestSFUAcademicCalendarAPIPrograms =
+    generateRequestSFUAcademicCalendarApiSectionFunction(
+        urls.academicCalendar.programs,
+    );

--- a/src/wrappers/courseOffering.ts
+++ b/src/wrappers/courseOffering.ts
@@ -1,4 +1,4 @@
-import { requestSFUCourseOutlinesAPI } from '@utils';
+import { requestSFUCourseOutlinesApi } from '@utils';
 import type {
     CourseOutlinesYear,
     CourseOutlinesTerm,
@@ -113,7 +113,7 @@ export default async function courseOutline(
     term: CourseOutlinesTerm = 'current',
 ): Promise<Course> {
     const rawCourse: RawAPIResponseCourse = (
-        await requestSFUCourseOutlinesAPI(
+        await requestSFUCourseOutlinesApi(
             year,
             term,
             department,

--- a/test/wrappers/courseOffering.test.ts
+++ b/test/wrappers/courseOffering.test.ts
@@ -2,6 +2,12 @@ import courseOffering from '../../src/wrappers/courseOffering';
 
 describe('courseOffering', () => {
     test('request', async () => {
-        const courseOutlineData = await courseOffering('cmpt', 120, 'd100', 2021, 'fall');
+        const courseOutlineData = await courseOffering(
+            'cmpt',
+            120,
+            'd100',
+            2021,
+            'fall',
+        );
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "compilerOptions": {
         "baseUrl": "./src",
         "rootDir": "./src",
-        "outDir": "./dist",
-        "declarationDir": "./dist/types",
+        "outDir": "./lib",
+        "declarationDir": "./lib/types",
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,


### PR DESCRIPTION
Clean up the code in src/api-types and src/utils. In src/api-types, functions were made to generate functions to prevent code duplication. For changing dist to lib, the change was done to make it clear that this code is meant to be used as a library by other code. Also, `npm pack` was tested and works.