### PR TITLE
Add error handling to API requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "course-api-wrapper",
     "version": "1.0.0",
-    "description": "An asynchronous TypeScript wrapper for SFU's course API.",
+    "description": "An asynchronous TypeScript wrapper for SFU's course API. This package is not endorsed or supported by SFU.",
     "main": "lib/index.js",
     "types": "lib/types/index.d.ts",
     "files": [

--- a/src/api-types/response/Course/processed/CourseSectionSummary.ts
+++ b/src/api-types/response/Course/processed/CourseSectionSummary.ts
@@ -2,7 +2,7 @@ import { CourseType, SectionCode } from '@api-types';
 
 interface CourseSectionSummary {
     sectionName: string; // number here is actually section (ex. "D100").
-    section: string; // If number is "D100", then value is "d100".
+    section: string; // If `sectionName` is "D100", then `section` is "d100".
     status: 'a'; // Don't know what the possible values of this is.
     type: CourseType; // Ex. "lecture".
     sectionCode: SectionCode; // Ex. "LEC".

--- a/src/api-types/response/Course/raw/RawCourseSectionSummary.ts
+++ b/src/api-types/response/Course/raw/RawCourseSectionSummary.ts
@@ -2,7 +2,7 @@ import { CourseType, SectionCode } from '@api-types';
 
 interface RawCourseSectionSummary {
     number: string; // Number here is actually section (ex. "D100").
-    value: string; // If number is "D100", then value is "d100".
+    value: string; // If `number` is "D100", then `value` is "d100".
     classStatus: 'a'; // Don't know what the possible values of this is.
     classType: CourseType; // Ex. "lecture".
     sectionCode: SectionCode; // Ex. "LEC".

--- a/src/errors/EmptyResponseError.ts
+++ b/src/errors/EmptyResponseError.ts
@@ -1,0 +1,6 @@
+export default class EmptyResponseError extends Error {
+    constructor(url: string) {
+        super(`API returned empty list when requesting: ${url}`);
+        this.name = 'EmptyResponseError';
+    }
+}

--- a/src/errors/InvalidResponseError.ts
+++ b/src/errors/InvalidResponseError.ts
@@ -1,0 +1,6 @@
+export default class InvalidResponseError extends Error {
+    constructor(errorCode: number, url: string) {
+        super(`API returned ${errorCode} error when requesting: ${url}`);
+        this.name = 'InvalidResponseError';
+    }
+}

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,0 +1,6 @@
+export default class NotFoundError extends Error {
+    constructor(search: string) {
+        super(`The search for ${search} didn't return anything.`);
+        this.name = 'NotFoundError';
+    }
+}

--- a/src/errors/RetryLimitReachedError.ts
+++ b/src/errors/RetryLimitReachedError.ts
@@ -1,0 +1,6 @@
+export default class RetryLimitReachedError extends Error {
+    constructor(maxAttempts: number, url: string) {
+        super(`Retry limit (${maxAttempts}) reached for: ${url}`);
+        this.name = 'RetryLimitReachedError';
+    }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,4 @@
+export { default as RetryLimitReachedError } from './RetryLimitReachedError';
+export { default as InvalidResponseError } from './InvalidResponseError';
+export { default as EmptyResponseError } from './EmptyResponseError';
+export { default as NotFoundError } from './NotFoundError';

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -1,5 +1,6 @@
 import apiConfig from '@config/api.json';
 import type { CourseOutlinesYear, CourseOutlinesTerm } from '@api-types';
+import { InvalidResponseError, RetryLimitReachedError } from '@errors';
 
 function generateURLForSFUApi(
     baseUrl: string,
@@ -18,22 +19,46 @@ function generateRequestSFUApiFunction(baseUrl: string): requestSFUApiFunction {
         for (let i = 0; i < apiConfig.requestRetry.maxAttempts; i++) {
             try {
                 const response = await fetch(url);
+
                 if (response.ok) {
                     return response;
+                } else {
+                    throw new InvalidResponseError(response.status, url);
                 }
-            } catch (error) {}
+            } catch (error) {
+                // If an error like 404 or whatnot was returned from the SFU
+                // API, that means `fetch` was able to connect and get a
+                // response from the server. This happens if
+                // `InvalidResponseError` is thrown, since that means a response
+                // was received, but `response.ok` is not true. Anyways, if a
+                // response is received, throw an error right away. If
+                // `InvalidResponseError` was not the error thrown, that means
+                // `fetch` threw an error. `fetch` does this for things like
+                // network errors. This can happen if the SFU API is being
+                // spammed and momentarily goes down. So, if some netork-related
+                // error happens, try making the request more times. That way,
+                // there is a chance the request could actually succeed. If
+                // after a maximum never of retry attempts errors are still
+                // received, throw an error to represent failure.
+                if (error instanceof InvalidResponseError) {
+                    throw error;
+                }
 
-            // console.error(`SFU API request failed for: ${url}, retrying...`);
-
-            if (i !== apiConfig.requestRetry.maxAttempts - 1) {
-                await new Promise((resolve) =>
-                    setTimeout(resolve, apiConfig.requestRetry.delay),
-                );
+                if (i !== apiConfig.requestRetry.maxAttempts - 1) {
+                    console.error(
+                        error,
+                        `SFU API request failed for: '${url}', retrying after ${apiConfig.requestRetry.delay} ms...`,
+                    );
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, apiConfig.requestRetry.delay),
+                    );
+                }
             }
         }
 
-        throw new Error(
-            `Retry limit (${apiConfig.requestRetry.maxAttempts}) reached for: ${url}`,
+        throw new RetryLimitReachedError(
+            apiConfig.requestRetry.maxAttempts,
+            url,
         );
     };
 }

--- a/src/wrappers/department.ts
+++ b/src/wrappers/department.ts
@@ -1,0 +1,19 @@
+import { CourseOutlinesTerm, CourseOutlinesYear } from '@api-types';
+import { Department } from '@api';
+import wrappers from '@wrappers';
+import { NotFoundError } from '@errors';
+
+export default async function department(
+    department: string,
+    year: CourseOutlinesYear = 'current',
+    term: CourseOutlinesTerm = 'current',
+): Promise<Department> {
+    const departments = await wrappers.departments(year, term);
+
+    const foundDepartment = departments.find((dept) => dept.id === department);
+    if (foundDepartment === undefined) {
+        throw new NotFoundError(department);
+    }
+
+    return foundDepartment;
+}

--- a/src/wrappers/departmentCourseNumbers.ts
+++ b/src/wrappers/departmentCourseNumbers.ts
@@ -4,6 +4,7 @@ import type {
     CourseOutlinesTerm,
     RawDepartmentCourse,
 } from '@api-types';
+import { EmptyResponseError } from '@errors';
 
 export default async function departmentCourseNumbers(
     department: string,
@@ -16,6 +17,10 @@ export default async function departmentCourseNumbers(
         department.toLowerCase(),
     );
     const rawDepartmentCourses: RawDepartmentCourse[] = await response.json();
+
+    if (rawDepartmentCourses.length === 0) {
+        throw new EmptyResponseError(response.url);
+    }
 
     return rawDepartmentCourses.map((rawDepartmentCourse) =>
         rawDepartmentCourse.value.toUpperCase(),

--- a/src/wrappers/departmentCourses.ts
+++ b/src/wrappers/departmentCourses.ts
@@ -1,7 +1,4 @@
-import {
-    requestSFUAcademicCalendarApiCourses,
-    processAllRequests,
-} from '@utils';
+import { processAllRequests } from '@utils';
 import type { CourseOutlinesYear, CourseOutlinesTerm } from '@api-types';
 import { Course } from '@api';
 import wrappers from '@wrappers';

--- a/src/wrappers/departments.ts
+++ b/src/wrappers/departments.ts
@@ -5,6 +5,7 @@ import {
     RawDepartmentData,
 } from '@api-types';
 import { Department } from '@api';
+import { EmptyResponseError } from '@errors';
 
 export default async function departments(
     year: CourseOutlinesYear = 'current',
@@ -12,6 +13,10 @@ export default async function departments(
 ): Promise<Department[]> {
     const response = await requestSFUAcademicCalendarApiCourses(year, term);
     const rawDepartmentData: RawDepartmentData[] = await response.json();
+
+    if (rawDepartmentData.length === 0) {
+        throw new EmptyResponseError(response.url);
+    }
 
     return rawDepartmentData.map((rawDepartmentDataEntry) =>
         Department.fromRawDepartmentData(rawDepartmentDataEntry),

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -3,6 +3,7 @@ import courseSection from './courseSection';
 import departmentCourseNumbers from './departmentCourseNumbers';
 import departmentCourses from './departmentCourses';
 import departmentNames from './departments';
+import department from './department';
 import departments from './departments';
 import years from './years';
 import terms from './terms';
@@ -13,6 +14,7 @@ export default {
     departmentCourseNumbers: departmentCourseNumbers,
     departmentCourses: departmentCourses,
     departmentNames: departmentNames,
+    department: department,
     departments: departments,
     terms: terms,
     years: years,

--- a/test/wrappers/__snapshots__/department.test.ts.snap
+++ b/test/wrappers/__snapshots__/department.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`departments request department that exists 1`] = `
+Department {
+  "id": "cmpt",
+  "name": "Computing Science",
+}
+`;

--- a/test/wrappers/__snapshots__/terms.test.ts.snap
+++ b/test/wrappers/__snapshots__/terms.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`terms request terms 1`] = `
+exports[`terms request terms for valid year 1`] = `
 [
   "fall",
   "spring",

--- a/test/wrappers/department.test.ts
+++ b/test/wrappers/department.test.ts
@@ -1,0 +1,14 @@
+import wrappers from '../../src/wrappers';
+import { NotFoundError } from '../../src/errors';
+
+describe('departments', () => {
+    test('request department that exists', async () => {
+        const department = await wrappers.department('cmpt', 2022, 'fall');
+        expect(department).toMatchSnapshot();
+    }, 30000);
+    test('request department that does not exist', async () => {
+        await expect(wrappers.department('asdf', 2022, 'fall')).rejects.toThrow(
+            NotFoundError,
+        );
+    }, 30000);
+});

--- a/test/wrappers/departmentCourseNumbers.test.ts
+++ b/test/wrappers/departmentCourseNumbers.test.ts
@@ -1,4 +1,5 @@
 import wrappers from '../../src/wrappers';
+import { EmptyResponseError } from '../../src/errors';
 
 describe('departmentCourseNumbers', () => {
     test('request arch course numbers', async () => {
@@ -16,5 +17,10 @@ describe('departmentCourseNumbers', () => {
         });
 
         expect(departmentCourseNumbers).toMatchSnapshot();
+    }, 30000);
+    test('request course numbers for department that does not exist', async () => {
+        await expect(
+            wrappers.departmentCourseNumbers('asdf', 2023, 'fall'),
+        ).rejects.toThrow(EmptyResponseError);
     }, 30000);
 });

--- a/test/wrappers/departments.test.ts
+++ b/test/wrappers/departments.test.ts
@@ -1,8 +1,14 @@
 import wrappers from '../../src/wrappers';
+import { EmptyResponseError } from '../../src/errors';
 
 describe('departments', () => {
     test('request departments', async () => {
         const departments = await wrappers.departments(2022, 'fall');
         expect(departments).toMatchSnapshot();
+    }, 30000);
+    test('request departments from an invalid year and term combination', async () => {
+        await expect(wrappers.departments(3, 'fall')).rejects.toThrow(
+            EmptyResponseError,
+        );
     }, 30000);
 });

--- a/test/wrappers/terms.test.ts
+++ b/test/wrappers/terms.test.ts
@@ -1,8 +1,15 @@
 import wrappers from '../../src/wrappers';
+import { InvalidResponseError } from '../../src/errors';
 
 describe('terms', () => {
-    test('request terms', async () => {
+    test('request terms for valid year', async () => {
         const terms = await wrappers.terms(2021);
         expect(terms).toMatchSnapshot();
+    }, 30000);
+
+    test('request terms for invalid year', async () => {
+        await expect(wrappers.terms(1910)).rejects.toThrow(
+            InvalidResponseError,
+        );
     }, 30000);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
             "@api-types": ["./api-types"],
             "@api": ["./api"],
             "@api/*": ["./api/*"],
-            "@config/*": ["./config/*"]
+            "@config/*": ["./config/*"],
+            "@errors": ["./errors"]
         },
         "plugins": [
             {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -10,7 +10,8 @@
             "@api-types": ["../src/api-types"],
             "@api": ["../src/api"],
             "@api/*": ["../src/api/*"],
-            "@config/*": ["../src/config/*"]
+            "@config/*": ["../src/config/*"],
+            "@errors": ["../src/errors"]
         }
     },
     "include": ["./test"]


### PR DESCRIPTION
Changes made include:
- Handling errors where invalid API requests are made.
- A `department` wrapper function.
- Test cases to test the new errors.