### PR TITLE
feat: add wrapper test delay and fail fast for 404

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,7 @@
 import { pathsToModuleNameMapper } from 'ts-jest';
 import { compilerOptions } from './tsconfig.test.json';
 
-export default {
+const commonConfig = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     // moduleNameMapper and modulePaths are needed for TypeScript custom paths,
@@ -14,4 +14,25 @@ export default {
         '.ts$': ['ts-jest', { tsconfig: './tsconfig.test.json' }],
     },
     modulePathIgnorePatterns: ['<rootDir>/docs/'],
+};
+
+export default {
+    projects: [
+        {
+            // Separate the `wrappers` test folder, since a delay should be
+            // added between tests in that folder. This is to prevent the API
+            // getting overwhelmed and returning errors when it is not expected
+            // to.
+            ...commonConfig,
+            displayName: 'wrappers',
+            testMatch: ['<rootDir>/test/wrappers/**/*.test.ts'],
+            setupFilesAfterEnv: ['<rootDir>/test/wrappers/jest.setup.ts'],
+        },
+        {
+            ...commonConfig,
+            displayName: 'default',
+            testMatch: ['<rootDir>/test/**/*.test.ts'],
+            testPathIgnorePatterns: ['<rootDir>/test/wrappers/'],
+        },
+    ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "course-api-wrapper",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "course-api-wrapper",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "course-api-wrapper",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "course-api-wrapper",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.6",
@@ -36,12 +36,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
+            "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.24.7",
+                "@babel/highlight": "^7.25.7",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -49,30 +49,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.25.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
-            "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
+            "version": "7.25.8",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.8.tgz",
+            "integrity": "sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.25.2",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
-            "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+            "version": "7.25.8",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.8.tgz",
+            "integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.25.0",
-                "@babel/helper-compilation-targets": "^7.25.2",
-                "@babel/helper-module-transforms": "^7.25.2",
-                "@babel/helpers": "^7.25.0",
-                "@babel/parser": "^7.25.0",
-                "@babel/template": "^7.25.0",
-                "@babel/traverse": "^7.25.2",
-                "@babel/types": "^7.25.2",
+                "@babel/code-frame": "^7.25.7",
+                "@babel/generator": "^7.25.7",
+                "@babel/helper-compilation-targets": "^7.25.7",
+                "@babel/helper-module-transforms": "^7.25.7",
+                "@babel/helpers": "^7.25.7",
+                "@babel/parser": "^7.25.8",
+                "@babel/template": "^7.25.7",
+                "@babel/traverse": "^7.25.7",
+                "@babel/types": "^7.25.8",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -88,29 +88,29 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
-            "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
+            "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.25.6",
+                "@babel/types": "^7.25.7",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
-                "jsesc": "^2.5.1"
+                "jsesc": "^3.0.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.25.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
-            "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
+            "integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.25.2",
-                "@babel/helper-validator-option": "^7.24.8",
-                "browserslist": "^4.23.1",
+                "@babel/compat-data": "^7.25.7",
+                "@babel/helper-validator-option": "^7.25.7",
+                "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -119,28 +119,28 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
+            "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
             "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.25.7",
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.25.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
-            "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
+            "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-simple-access": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "@babel/traverse": "^7.25.2"
+                "@babel/helper-module-imports": "^7.25.7",
+                "@babel/helper-simple-access": "^7.25.7",
+                "@babel/helper-validator-identifier": "^7.25.7",
+                "@babel/traverse": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -150,74 +150,74 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-            "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
+            "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-            "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
+            "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
             "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.25.7",
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
+            "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
+            "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-            "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
+            "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
-            "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
+            "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.25.0",
-                "@babel/types": "^7.25.6"
+                "@babel/template": "^7.25.7",
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
+            "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.25.7",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -298,12 +298,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-            "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+            "version": "7.25.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
+            "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.25.6"
+                "@babel/types": "^7.25.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -364,12 +364,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
-            "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.7.tgz",
+            "integrity": "sha512-AqVo+dguCgmpi/3mYBdu9lkngOBlQ2w2vnNpa6gfiCxQZLzV4ZbhsXitJ2Yblkoe1VQwtHSaNmIaGll/26YWRw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -403,12 +403,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.7.tgz",
+            "integrity": "sha512-ruZOnKO+ajVL/MVx+PwNBPOkrnXTXoWMtte1MBpegfCArhqOe3Bj52avVj1huLLxNKYKXYaSxZ2F+woK1ekXfw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -520,12 +520,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.25.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
-            "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.7.tgz",
+            "integrity": "sha512-rR+5FDjpCHqqZN2bzZm18bVYGaejGq5ZkpVCJLXor/+zlSrSoc4KWcHI0URVWjl/68Dyr1uwZUz/1njycEAv9g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -535,30 +535,30 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-            "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
+            "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/parser": "^7.25.0",
-                "@babel/types": "^7.25.0"
+                "@babel/code-frame": "^7.25.7",
+                "@babel/parser": "^7.25.7",
+                "@babel/types": "^7.25.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
-            "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
+            "version": "7.25.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
+            "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.25.6",
-                "@babel/parser": "^7.25.6",
-                "@babel/template": "^7.25.0",
-                "@babel/types": "^7.25.6",
+                "@babel/code-frame": "^7.25.7",
+                "@babel/generator": "^7.25.7",
+                "@babel/parser": "^7.25.7",
+                "@babel/template": "^7.25.7",
+                "@babel/types": "^7.25.7",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -567,13 +567,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-            "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+            "version": "7.25.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
+            "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.8",
-                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/helper-string-parser": "^7.25.7",
+                "@babel/helper-validator-identifier": "^7.25.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -1056,54 +1056,54 @@
             }
         },
         "node_modules/@shikijs/core": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.21.0.tgz",
-            "integrity": "sha512-zAPMJdiGuqXpZQ+pWNezQAk5xhzRXBNiECFPcJLtUdsFM3f//G95Z15EHTnHchYycU8kIIysqGgxp8OVSj1SPQ==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.22.0.tgz",
+            "integrity": "sha512-S8sMe4q71TJAW+qG93s5VaiihujRK6rqDFqBnxqvga/3LvqHEnxqBIOPkt//IdXVtHkQWKu4nOQNk0uBGicU7Q==",
             "dev": true,
             "dependencies": {
-                "@shikijs/engine-javascript": "1.21.0",
-                "@shikijs/engine-oniguruma": "1.21.0",
-                "@shikijs/types": "1.21.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
+                "@shikijs/engine-javascript": "1.22.0",
+                "@shikijs/engine-oniguruma": "1.22.0",
+                "@shikijs/types": "1.22.0",
+                "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.3"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.21.0.tgz",
-            "integrity": "sha512-jxQHNtVP17edFW4/0vICqAVLDAxmyV31MQJL4U/Kg+heQALeKYVOWo0sMmEZ18FqBt+9UCdyqGKYE7bLRtk9mg==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.22.0.tgz",
+            "integrity": "sha512-AeEtF4Gcck2dwBqCFUKYfsCq0s+eEbCEbkUuFou53NZ0sTGnJnJ/05KHQFZxpii5HMXbocV9URYVowOP2wH5kw==",
             "dev": true,
             "dependencies": {
-                "@shikijs/types": "1.21.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
+                "@shikijs/types": "1.22.0",
+                "@shikijs/vscode-textmate": "^9.3.0",
                 "oniguruma-to-js": "0.4.3"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.21.0.tgz",
-            "integrity": "sha512-AIZ76XocENCrtYzVU7S4GY/HL+tgHGbVU+qhiDyNw1qgCA5OSi4B4+HY4BtAoJSMGuD/L5hfTzoRVbzEm2WTvg==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.22.0.tgz",
+            "integrity": "sha512-5iBVjhu/DYs1HB0BKsRRFipRrD7rqjxlWTj4F2Pf+nQSPqc3kcyqFFeZXnBMzDf0HdqaFVvhDRAGiYNvyLP+Mw==",
             "dev": true,
             "dependencies": {
-                "@shikijs/types": "1.21.0",
-                "@shikijs/vscode-textmate": "^9.2.2"
+                "@shikijs/types": "1.22.0",
+                "@shikijs/vscode-textmate": "^9.3.0"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.21.0.tgz",
-            "integrity": "sha512-tzndANDhi5DUndBtpojEq/42+dpUF2wS7wdCDQaFtIXm3Rd1QkrcVgSSRLOvEwexekihOXfbYJINW37g96tJRw==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.22.0.tgz",
+            "integrity": "sha512-Fw/Nr7FGFhlQqHfxzZY8Cwtwk5E9nKDUgeLjZgt3UuhcM3yJR9xj3ZGNravZZok8XmEZMiYkSMTPlPkULB8nww==",
             "dev": true,
             "dependencies": {
-                "@shikijs/vscode-textmate": "^9.2.2",
+                "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4"
             }
         },
         "node_modules/@shikijs/vscode-textmate": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz",
-            "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
+            "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
             "dev": true
         },
         "node_modules/@sinclair/typebox": {
@@ -1257,9 +1257,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "22.7.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-            "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+            "version": "22.7.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
+            "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
@@ -1299,9 +1299,9 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.12.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+            "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -1611,9 +1611,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001666",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001666.tgz",
-            "integrity": "sha512-gD14ICmoV5ZZM1OdzPWmpx+q4GyefaK06zi8hmfHV5xe4/2nOQX3+Dw5o+fSqOws2xVwL9j+anOPFwHzdEdV4g==",
+            "version": "1.0.30001669",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
+            "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
             "dev": true,
             "funding": [
                 {
@@ -1928,9 +1928,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.31",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.31.tgz",
-            "integrity": "sha512-QcDoBbQeYt0+3CWcK/rEbuHvwpbT/8SV9T3OSgs6cX1FlcUAkgrkqbg9zLnDrMM/rLamzQwal4LYFCiWk861Tg==",
+            "version": "1.5.41",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.41.tgz",
+            "integrity": "sha512-dfdv/2xNjX0P8Vzme4cfzHqnPm5xsZXwsolTYr0eyW18IUmNyG08vL+fttvinTfhKfIKdRoqkDIC9e9iWQCNYQ==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -3176,15 +3176,15 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
             "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/json-parse-even-better-errors": {
@@ -3734,9 +3734,9 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true
         },
         "node_modules/picomatch": {
@@ -3868,9 +3868,9 @@
             "dev": true
         },
         "node_modules/regex": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.2.tgz",
-            "integrity": "sha512-kK/AA3A9K6q2js89+VMymcboLOlF5lZRCYJv3gzszXFHBr6kO6qLGzbm+UIugBEV8SMMKCTR59txoY6ctRHYVw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.3.tgz",
+            "integrity": "sha512-r/AadFO7owAq1QJVeZ/nq9jNS1vyZt+6t1p/E59B56Rn2GCya+gr1KSyOzNL/er+r+B7phv5jG2xU2Nz1YkmJg==",
             "dev": true
         },
         "node_modules/require-directory": {
@@ -4026,16 +4026,16 @@
             }
         },
         "node_modules/shiki": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.21.0.tgz",
-            "integrity": "sha512-apCH5BoWTrmHDPGgg3RF8+HAAbEL/CdbYr8rMw7eIrdhCkZHdVGat5mMNlRtd1erNG01VPMIKHNQ0Pj2HMAiog==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.22.0.tgz",
+            "integrity": "sha512-/t5LlhNs+UOKQCYBtl5ZsH/Vclz73GIqT2yQsCBygr8L/ppTdmpL4w3kPLoZJbMKVWtoG77Ue1feOjZfDxvMkw==",
             "dev": true,
             "dependencies": {
-                "@shikijs/core": "1.21.0",
-                "@shikijs/engine-javascript": "1.21.0",
-                "@shikijs/engine-oniguruma": "1.21.0",
-                "@shikijs/types": "1.21.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
+                "@shikijs/core": "1.22.0",
+                "@shikijs/engine-javascript": "1.22.0",
+                "@shikijs/engine-oniguruma": "1.22.0",
+                "@shikijs/types": "1.22.0",
+                "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4"
             }
         },
@@ -4448,9 +4448,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.26.7",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.7.tgz",
-            "integrity": "sha512-gUeI/Wk99vjXXMi8kanwzyhmeFEGv1LTdTQsiyIsmSYsBebvFxhbcyAx7Zjo4cMbpLGxM4Uz3jVIjksu/I2v6Q==",
+            "version": "0.26.10",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.10.tgz",
+            "integrity": "sha512-xLmVKJ8S21t+JeuQLNueebEuTVphx6IrP06CdV7+0WVflUSW3SPmR+h1fnWVdAR/FQePEgsSWCUHXqKKjzuUAw==",
             "dev": true,
             "dependencies": {
                 "lunr": "^2.3.9",
@@ -4494,9 +4494,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -4794,9 +4794,9 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+            "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
             "dev": true,
             "bin": {
                 "yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1257,9 +1257,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
-            "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
+            "version": "22.7.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+            "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
@@ -4448,9 +4448,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.26.10",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.10.tgz",
-            "integrity": "sha512-xLmVKJ8S21t+JeuQLNueebEuTVphx6IrP06CdV7+0WVflUSW3SPmR+h1fnWVdAR/FQePEgsSWCUHXqKKjzuUAw==",
+            "version": "0.26.7",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.7.tgz",
+            "integrity": "sha512-gUeI/Wk99vjXXMi8kanwzyhmeFEGv1LTdTQsiyIsmSYsBebvFxhbcyAx7Zjo4cMbpLGxM4Uz3jVIjksu/I2v6Q==",
             "dev": true,
             "dependencies": {
                 "lunr": "^2.3.9",
@@ -4494,9 +4494,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+            "version": "5.4.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ],
     "scripts": {
         "prepare": "ts-patch install -s",
-        "test": "jest",
+        "test": "jest --runInBand",
         "build": "tsc",
         "clean": "rimraf lib",
         "generate-docs": "typedoc src/index.ts --out ./docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "course-api-wrapper",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "An asynchronous TypeScript wrapper for SFU's course API. This package is not endorsed or supported by SFU.",
     "main": "lib/index.js",
     "types": "lib/types/index.d.ts",

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -26,22 +26,30 @@ function generateRequestSFUApiFunction(baseUrl: string): requestSFUApiFunction {
                     throw new InvalidResponseError(response.status, url);
                 }
             } catch (error) {
+                // `InvalidResponseError` could either be because the API is
+                // overwhelmed, or an actual error such as 404. An error
+                // *actually* from `fetch` will be a network error.
+
+                // If an `InvalidResponseError` is encountered, throw it anyways
+                // right away. This is only an issue if the API is currently
+                // being spammed and returns an error such as a 404 error when
+                // the requested object does not exist. However, this shouldn't
+                // be an issue if API requests are made with a slight delay
+                // between requests. Note that it is possible for the API to
+                // (incorrectly) return an empty list instead of a list of
+                // objects when spammed too. Essentially, if the API request
+                // type would normally return a 404 error or an empty list when
+                // the request type response does not exist, the API could
+                // return that error when being spammed, even if the requested
+                // object does exist.
+                if (error instanceof InvalidResponseError) {
+                    throw error;
+                }
+
                 if (i !== apiConfig.requestRetry.maxAttempts - 1) {
                     await new Promise((resolve) =>
                         setTimeout(resolve, apiConfig.requestRetry.delay),
                     );
-                } else {
-                    // `InvalidResponseError` could either be because the API is
-                    // overwhelmed, or an actual error such as 404. An error
-                    // *actually* from `fetch` will be a network error. Since an
-                    // error like 404 is unclear (whether it is from the API
-                    // being spammed or an actual 404 error), try again. The
-                    // issue with this is that an actual 404 will keep getting
-                    // requested. This is better than returning 404 right away
-                    // when it is just the API being spammed.
-                    if (error instanceof InvalidResponseError) {
-                        throw error;
-                    }
                 }
             }
         }

--- a/test/wrappers/jest.setup.ts
+++ b/test/wrappers/jest.setup.ts
@@ -1,0 +1,8 @@
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const msDelay = 1000;
+
+beforeEach(async () => {
+    // Add a delay before each test in the wrappers test folder. This is to
+    // prevent the API from being overloaded.
+    await delay(msDelay);
+}, msDelay + 1000);


### PR DESCRIPTION
Add a delay between wrapper tests and fail fast for 404 errors. This way, errors from the API being spammed should not happen during tests. Then, this wrapper code can be modified to fail immediately if a 404 error is received from the API. Such an error should very likely actually be a 404 error, as long as the API is not being spammed.