### PR TITLE
fix: handle course schedules with no days

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "course-api-wrapper",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "description": "An asynchronous TypeScript wrapper for SFU's course API. This package is not endorsed or supported by SFU.",
     "main": "lib/index.js",
     "types": "lib/types/index.d.ts",

--- a/src/utils/process/processStringDays.ts
+++ b/src/utils/process/processStringDays.ts
@@ -1,6 +1,11 @@
 import { Day } from '@api-types';
 
 function processStringDays(inputDays: string): Day[] {
+    if (inputDays === '') {
+        // This could happen for an online-only course.
+        return [];
+    }
+
     // Days are separated by ', '.
     const splitDays = inputDays.split(', ');
     return splitDays.map((splitDay) => {


### PR DESCRIPTION
If the days string is the empty string, return an empty list.