### PR TITLE
feat: do not throw empty response error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "course-api-wrapper",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "An asynchronous TypeScript wrapper for SFU's course API. This package is not endorsed or supported by SFU.",
     "main": "lib/index.js",
     "types": "lib/types/index.d.ts",

--- a/src/wrappers/departmentCourseNumbers.ts
+++ b/src/wrappers/departmentCourseNumbers.ts
@@ -4,7 +4,6 @@ import type {
     CourseOutlinesTerm,
     RawDepartmentCourse,
 } from '@api-types';
-import { EmptyResponseError } from '@errors';
 
 export default async function departmentCourseNumbers(
     department: string,
@@ -17,10 +16,6 @@ export default async function departmentCourseNumbers(
         department.toLowerCase(),
     );
     const rawDepartmentCourses: RawDepartmentCourse[] = await response.json();
-
-    if (rawDepartmentCourses.length === 0) {
-        throw new EmptyResponseError(response.url);
-    }
 
     return rawDepartmentCourses.map((rawDepartmentCourse) =>
         rawDepartmentCourse.value.toUpperCase(),

--- a/src/wrappers/departments.ts
+++ b/src/wrappers/departments.ts
@@ -5,7 +5,6 @@ import {
     RawDepartmentData,
 } from '@api-types';
 import { Department } from '@api';
-import { EmptyResponseError } from '@errors';
 
 export default async function departments(
     year: CourseOutlinesYear = 'current',
@@ -13,10 +12,6 @@ export default async function departments(
 ): Promise<Department[]> {
     const response = await requestSFUAcademicCalendarApiCourses(year, term);
     const rawDepartmentData: RawDepartmentData[] = await response.json();
-
-    if (rawDepartmentData.length === 0) {
-        throw new EmptyResponseError(response.url);
-    }
 
     return rawDepartmentData.map((rawDepartmentDataEntry) =>
         Department.fromRawDepartmentData(rawDepartmentDataEntry),

--- a/test/wrappers/departmentCourseNumbers.test.ts
+++ b/test/wrappers/departmentCourseNumbers.test.ts
@@ -1,5 +1,4 @@
 import wrappers from '../../src/wrappers';
-import { EmptyResponseError } from '../../src/errors';
 
 describe('departmentCourseNumbers', () => {
     test('request arch course numbers', async () => {
@@ -19,8 +18,12 @@ describe('departmentCourseNumbers', () => {
         expect(departmentCourseNumbers).toMatchSnapshot();
     }, 30000);
     test('request course numbers for department that does not exist', async () => {
-        await expect(
-            wrappers.departmentCourseNumbers('asdf', 2023, 'fall'),
-        ).rejects.toThrow(EmptyResponseError);
+        const departmentCourseNumbers = await wrappers.departmentCourseNumbers(
+            'asdf',
+            2023,
+            'fall',
+        );
+
+        expect(departmentCourseNumbers).toEqual([]);
     }, 30000);
 });

--- a/test/wrappers/departments.test.ts
+++ b/test/wrappers/departments.test.ts
@@ -1,5 +1,4 @@
 import wrappers from '../../src/wrappers';
-import { EmptyResponseError } from '../../src/errors';
 
 describe('departments', () => {
     test('request departments', async () => {
@@ -7,8 +6,8 @@ describe('departments', () => {
         expect(departments).toMatchSnapshot();
     }, 30000);
     test('request departments from an invalid year and term combination', async () => {
-        await expect(wrappers.departments(3, 'fall')).rejects.toThrow(
-            EmptyResponseError,
-        );
+        const departments = await wrappers.departments(3, 'fall');
+
+        expect(departments).toEqual([]);
     }, 30000);
 });


### PR DESCRIPTION
This error can be thrown when there wasn't actually an API error. It is possible for an empty response to be the "true" response.

This issue is because an empty array is used as a response for both cases like: "that department exists and has no courses" and "that department does not exist, and so no courses exist for this non-existing department".

I think it is better to not throw the error though. A user can handle requesting a department that doesn't exist themselves.